### PR TITLE
the -v flag for tar is unsupported on older and bsd versions of tar, …

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -3,5 +3,6 @@ source 'https://supermarket.chef.io'
 metadata
 
 group :integration do
+  cookbook 'apt'
   cookbook 'remote_install_test', path: 'test/fixtures/cookbooks/remote_install_test'
 end

--- a/libraries/remote_install.rb
+++ b/libraries/remote_install.rb
@@ -118,7 +118,7 @@ EOH
     end
 
     def extract
-      extract_command = 'tar -xv'
+      extract_command = 'tar -x'
       extract_command << 'z' if new_resource.source =~ /\.gz/
       extract_command << 'j' if new_resource.source =~ /\.bz2/
 

--- a/test/integration/remote_install_test/serverspec/install_spec.rb
+++ b/test/integration/remote_install_test/serverspec/install_spec.rb
@@ -1,10 +1,9 @@
 require 'serverspec'
 
-include Serverspec::Helper::Exec
-include Serverspec::Helper::DetectOS
+set :backend, :exec
 
 describe 'bash' do
   describe command('/usr/local/bin/bash --version') do
-    it { should return_stdout(/4\.3/) }
+    its(:stdout) { should match /4\.3/ }
   end
 end


### PR DESCRIPTION
…which is an issue on older platforms