### PR TITLE
Silence deprecation warnings about ChefSpec.define_matcher

### DIFF
--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,5 +1,5 @@
 if defined?(ChefSpec)
-  ChefSpec::Runner.define_runner_method :remote_install
+  ChefSpec.define_matcher :remote_install
 
   def install_remote_install(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new(:remote_install, :install, resource_name)


### PR DESCRIPTION
```
[DEPRECATION] `ChefSpec::Runner.define_runner_method' is deprecated. It is being used in the remote_install resource matcher. Please use `ChefSpec.define_matcher' instead. (called from spec/recipes/bash_spec.rb:4:in `block (2 levels) in <top (required)>')
```