### PR TITLE
Reference `new_resource` instead of non-existent `resource`

### DIFF
--- a/resources/remote_install.rb
+++ b/resources/remote_install.rb
@@ -86,9 +86,9 @@ action_class do
 
     unless new_resource.checksum == checksum
       raise <<-EOH
-Verification for #{resource} failed due to a checksum mismatch:
+Verification for #{new_resource} failed due to a checksum mismatch:
 
-  expected: #{resource.checksum}
+  expected: #{new_resource.checksum}
   actual:   #{actual}
 
 This added security check is used to prevent MITM attacks when downloading the


### PR DESCRIPTION
### Description

Prevent a `NameError: undefined` when checksums mismatch, by referencing the available variable 

### Issues Resolved

#18 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
    pending
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
